### PR TITLE
Initialize Hydrasdr devices when creating a source device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,25 @@ set(GR_PKG_CONF_DIR     ${GR_CONF_DIR}/${CMAKE_PROJECT_NAME}/conf.d)
 set(GR_PKG_LIBEXEC_DIR  ${GR_LIBEXEC_DIR}/${CMAKE_PROJECT_NAME})
 
 ########################################################################
+# Determine location of Python pybind3/swig interface library
+# Note: applicable only to non-packaged installs
+########################################################################
+execute_process(COMMAND python3 -c "
+import os
+import sys
+from distutils import sysconfig
+m1 = os.path.join('${CMAKE_INSTALL_PREFIX}', 'lib', 'python' + '.'.join(sys.version.split('.')[:2]), 'dist-packages')
+m2 = sysconfig.get_python_lib(plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}')
+ok2 = m2 in sys.path
+if ok2:
+	print(m2)
+else:
+	print(m1)
+	" OUTPUT_VARIABLE OSMOSDR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+MESSAGE(STATUS "OSMOSDR_PYTHON_DIR has been set to \"${OSMOSDR_PYTHON_DIR}\".")
+
+########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set
 ########################################################################
 if(APPLE)

--- a/README-install.md
+++ b/README-install.md
@@ -1,0 +1,39 @@
+Forked from official Osmocom gr-osmosdr with additions to support HydraSDR
+
+This version of gr-osmosdr is intended to replace libgnuradio-osmosdr.so, which
+was likely to have already been installed from your OS distro's package repo.
+Having two different versions of the same library installed on the same system
+can lead to unexpected behavior and frustration as you try to figure out why your
+applications aren't working.  Please uninstall the packaged library prior to
+compiling and installing this one!  The install.sh script will try to prevent
+conflicts by looking at the package management system ("apt") but it does
+not guard against conflicts with other locally built code.
+
+Prerequisits:
+ * Fully installed gnuradio-3.8 or later
+ * Use of correct version of code depending on gnuradio version:
+   For gnuradio-3.10 or later, please "git checkout master" (this is the default).
+   For gnuradio-3.8, please "git checkout gr38" before installing.
+ * Drivers for SDR hardware already installed.  
+   e.g. librtlsdr-dev, libairspy-def, libsoapysdr-dev, rfone-host
+ * Developer built tools already installed.
+   e.g. build-essential, boost, cmake, git, ...
+
+Install process:
+   cd ~
+   git clone https://github.com/boatbod/gr-osmosdr
+   cd ~/gr-osmosdr
+   git checkout <master | gr38>            (this is an optional step)
+   ./install.sh
+
+Upon completion:
+ * Check results in the three log files
+   ~/gr-osmosdr/build/cmake.log            (right packages enabled?)
+   ~/gr-osmosdr/build/make.log             (build completed successfully?)
+   ~/gr-osmosdr/build/install.log          (installed properly?)
+
+Uninstall:
+ * It is possible to uninstall the driver as follows:
+   cd ~/gr-osmosdr/build
+   sudo make uninstall
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ hardware, including:
  * Fairwaves XTRX through [libxtrx](https://github.com/myriadrf/libxtrx)
  * Red Pitaya SDR transceiver <http://bazaar.redpitaya.com>
  * FreeSRP through [libfreesrp](https://github.com/myriadrf/libfreesrp)
+
+Boatbod fork additions:
  * HydraSDR Wideband Receiver through [libhydrasdr](https://github.com/hydrasdr/rfone_host)
+ * Support for using multiple Airspy and HydraSDR devices by specifying serial number in args
 
 By using the gr-osmosdr block you can take advantage of a common software API in
 your application(s) independent of the underlying radio hardware.

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,7 +22,7 @@ include(GrPython)
 GR_PYTHON_INSTALL(
     FILES
     osmocom_siggen_base.py
-    DESTINATION ${GR_PYTHON_DIR}/osmosdr
+    DESTINATION ${OSMOSDR_PYTHON_DIR}/osmosdr
 )
 
 GR_PYTHON_INSTALL(

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,10 @@
 Source: gr-osmosdr
 Section: libdevel
 Priority: optional
-Maintainer: Harald Welte <laforge@gnumonks.org>
+Maintainer: Graham Norbury <gnorbury@bondcar.com>
 Build-Depends: cmake,
                debhelper (>= 9.0.0~),
-	       dh-python,
+               dh-python,
                doxygen,
                gnuradio-dev (>=3.7.11),
                gr-fcdproplus (>=3.7.25.4b6464b-3) [!hurd-i386],
@@ -15,23 +15,20 @@ Build-Depends: cmake,
                libboost-dev,
                libboost-system-dev,
                libboost-thread-dev,
-	       libfreesrp-dev [!hurd-i386],
+               libfreesrp-dev [!hurd-i386],
                libhackrf-dev [linux-any],
                liblog4cpp5-dev,
                libmirisdr-dev [!hurd-i386],
                libosmosdr-dev [!hurd-i386],
                librtlsdr-dev [!hurd-i386],
-	       libsoapysdr-dev,
+               libsoapysdr-dev,
                libuhd-dev (>=3.10),
                pkg-config,
                python-dev,
-	       python-soapysdr,
-               swig
-X-Python-Version: >= 2.7, << 2.8
+               python-soapysdr,
+X-Python-Version: >= 3.8
 Standards-Version: 4.1.0
-Homepage: https://osmocom.org/projects/gr-osmosdr/wiki
-Vcs-Git: https://gitea.osmocom.org/sdr/gr-osmosdr
-Vcs-Browser: https://gitea.osmocom.org/sdr/gr-osmosdr
+Homepage: https://github.org/boatbod/gr-osmosdr
 
 Package: gr-osmosdr
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ VER=$(shell dpkg-parsechangelog -l$(DEB_DEBIAN_DIR)/changelog \
 GITREV=$(shell echo $(VER) | sed -rne 's,[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.([0-f]+),\1,p')
 
 %:
-	dh $@ --with python2
+	dh $@ --with python3
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DLIB_SUFFIX="/$(DEB_HOST_MULTIARCH)" -DPythonLibs_FIND_VERSION:STRING="2.7" -DPYTHON_EXECUTABLE:STRING="/usr/bin/python"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+# gr-osmosdr install script for debian based systems
+
+GR_VER=$(apt list gnuradio 2>/dev/null | grep -m 1 gnuradio | cut -d' ' -f2 | cut -d'.' -f1,2)
+echo "Identified GNURadio version ${GR_VER}"
+if [ ${GR_VER} = "3.10" ]; then
+    echo "Installing for GNURadio 3.10"
+else
+    echo "Installing for GNURadio ${GR_VER} is not supported by this version of op25"
+    echo "Please use git branch \"gr38\" for GNURadio-3.8 or earlier"
+    exit 1
+fi
+
+GR_OSMOSDR=$(apt list gr-osmosdr 2>/dev/null | grep -o '\[.**\]')
+echo "Checking for gr-osmosdr package ${GR_OSMOSDR}"
+if [ "${GR_OSMOSDR}" != "" ]; then
+    echo "The gr-osmosdr package is presently installed. Please remove it before"
+    echo "re-running this install script."
+    exit 1
+fi
+
+rm -rf build
+mkdir build
+cd build
+echo "Configuring..."
+cmake ../         2>&1 | tee cmake.log
+echo "Compiling..."
+make              2>&1 | tee make.log
+echo "Installing..."
+sudo make install 2>&1 | tee install.log
+sudo ldconfig
+echo "...installation complete"
+

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,8 @@ fi
 GR_OSMOSDR=$(apt list gr-osmosdr 2>/dev/null | grep -o '\[.**\]')
 echo "Checking for gr-osmosdr package ${GR_OSMOSDR}"
 if [ "${GR_OSMOSDR}" != "" ]; then
-    echo "The gr-osmosdr package is presently installed. Please remove it before"
-    echo "re-running this install script."
+    echo "The gr-osmosdr package is presently installed."
+    echo "Please remove it before running this install script."
     exit 1
 fi
 

--- a/lib/airspy/airspy_source_c.cc
+++ b/lib/airspy/airspy_source_c.cc
@@ -96,11 +96,23 @@ airspy_source_c::airspy_source_c (const std::string &args)
     _bandwidth(0)
 {
   int ret;
-
+  _dev = NULL;
   dict_t dict = params_to_dict(args);
 
-  _dev = NULL;
-  ret = airspy_open( &_dev );
+  // the block below allows one to open airspy by serial number
+  // 2016-Apr-5 - by Lawrence Glaister VE7IT  ve7it@shaw.ca
+  // (allowing multiple airspy source blocks to be used) Note: each airspy should be
+  // plugged into its own USB bus controller to support the high data rates involved.
+  // osmocom Source block usage: Device arguments:  airspy=0x644064DC317C1FCD
+  // if no device arguments are given or s/n=0, the first found airspy device will be used
+  // use airspy_info utility to identify device serial number strings
+  uint64_t sn;
+  std::stringstream ss;
+  ss << std::hex << dict["airspy"];
+  ss >> sn;
+  std::cerr << "Attempting to open airspy by s/n= "
+            <<  boost::format("0x%016X") % (sn) << std::endl;
+  ret = airspy_open_sn( &_dev, sn );
   AIRSPY_THROW_ON_ERROR(ret, "Failed to open AirSpy device")
 
   uint8_t board_id;
@@ -111,11 +123,15 @@ airspy_source_c::airspy_source_c (const std::string &args)
   memset(version, 0, sizeof(version));
   ret = airspy_version_string_read( _dev, version, sizeof(version));
   AIRSPY_THROW_ON_ERROR(ret, "Failed to read version string")
-#if 0
+
   airspy_read_partid_serialno_t part_serial;
   ret = airspy_board_partid_serialno_read( _dev, &part_serial );
   AIRSPY_THROW_ON_ERROR(ret, "Failed to read serial number")
-#endif
+  std::cerr << "Opened Device Serial Number=    "
+    << boost::format("0x%08X") % (part_serial.serial_no[2])
+    << boost::format("%08X")   % (part_serial.serial_no[3])
+    << std::endl;
+
   uint32_t num_rates;
   airspy_get_samplerates(_dev, &num_rates, 0);
   uint32_t *samplerates = (uint32_t *) malloc(num_rates * sizeof(uint32_t));

--- a/lib/airspy/airspy_source_c.cc
+++ b/lib/airspy/airspy_source_c.cc
@@ -98,6 +98,8 @@ airspy_source_c::airspy_source_c (const std::string &args)
   int ret;
   _dev = NULL;
   dict_t dict = params_to_dict(args);
+  if (dict["airspy"] == "")
+    dict["airspy"] = "0";
 
   // the block below allows one to open airspy by serial number
   // 2016-Apr-5 - by Lawrence Glaister VE7IT  ve7it@shaw.ca

--- a/lib/hydrasdr/hydrasdr_source_c.cc
+++ b/lib/hydrasdr/hydrasdr_source_c.cc
@@ -97,11 +97,23 @@ hydrasdr_source_c::hydrasdr_source_c (const std::string &args)
     _bandwidth(0)
 {
   int ret;
-
+  _dev = NULL;
   dict_t dict = params_to_dict(args);
 
-  _dev = NULL;
-  ret = hydrasdr_open( &_dev );
+  // the block below allows one to open hydrasdr by serial number
+  // 2016-Apr-5 - by Lawrence Glaister VE7IT  ve7it@shaw.ca
+  // (allowing multiple hydrasdr source blocks to be used) Note: each hydrasdr should be
+  // plugged into its own USB bus controller to support the high data rates involved.
+  // osmocom Source block usage: Device arguments:  hydrasdr=0x644064DC317C1FCD
+  // if no device arguments are given or s/n=0, the first found hydrasdr device will be used
+  // use hydrasdr_info utility to identify device serial number strings
+  uint64_t sn;
+  std::stringstream ss;
+  ss << std::hex << dict["hydrasdr"];
+  ss >> sn;
+  std::cerr << "Attempting to open hydrasdr by s/n= "
+            <<  boost::format("0x%016X") % (sn) << std::endl;
+  ret = hydrasdr_open_sn( &_dev, sn );
   HYDRASDR_THROW_ON_ERROR(ret, "Failed to open HydraSDR device")
 
   uint8_t board_id;
@@ -112,11 +124,15 @@ hydrasdr_source_c::hydrasdr_source_c (const std::string &args)
   memset(version, 0, sizeof(version));
   ret = hydrasdr_version_string_read( _dev, version, sizeof(version));
   HYDRASDR_THROW_ON_ERROR(ret, "Failed to read version string")
-#if 0
+
   hydrasdr_read_partid_serialno_t part_serial;
   ret = hydrasdr_board_partid_serialno_read( _dev, &part_serial );
   HYDRASDR_THROW_ON_ERROR(ret, "Failed to read serial number")
-#endif
+  std::cerr << "Opened Device Serial Number=    "
+    << boost::format("0x%08X") % (part_serial.serial_no[2])
+    << boost::format("%08X")   % (part_serial.serial_no[3])
+    << std::endl;
+
   uint32_t num_rates;
   hydrasdr_get_samplerates(_dev, &num_rates, 0);
   uint32_t *samplerates = (uint32_t *) malloc(num_rates * sizeof(uint32_t));

--- a/lib/hydrasdr/hydrasdr_source_c.cc
+++ b/lib/hydrasdr/hydrasdr_source_c.cc
@@ -99,6 +99,8 @@ hydrasdr_source_c::hydrasdr_source_c (const std::string &args)
   int ret;
   _dev = NULL;
   dict_t dict = params_to_dict(args);
+  if (dict["hydrasdr"] == "")
+    dict["hydrasdr"] = "0";
 
   // the block below allows one to open hydrasdr by serial number
   // 2016-Apr-5 - by Lawrence Glaister VE7IT  ve7it@shaw.ca

--- a/lib/hydrasdr/hydrasdr_source_c.cc
+++ b/lib/hydrasdr/hydrasdr_source_c.cc
@@ -306,8 +306,10 @@ int hydrasdr_source_c::work( int noutput_items,
   if ( _dev )
     running = (hydrasdr_is_streaming( _dev ) == HYDRASDR_TRUE);
 
-  if ( ! running )
+  if ( ! running ) {
+    std::cerr << "HydraSDR has unexpectedly stopped RX streaming)" << std::endl;
     return WORK_DONE;
+  }
 
   std::unique_lock<std::mutex> lock(_fifo_lock);
 

--- a/lib/sink_impl.cc
+++ b/lib/sink_impl.cc
@@ -109,7 +109,7 @@ sink_impl::sink_impl( const std::string &args )
   dev_types.push_back("file");
 #endif
 
-  std::cerr << "gr-osmosdr "
+  std::cerr << "gr-osmosdr (boatbod) "
             << GR_OSMOSDR_VERSION << " (" << GR_OSMOSDR_LIBVER << ") "
             << "gnuradio " << gr::version() << std::endl;
   std::cerr << "built-in sink types: ";

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -96,6 +96,10 @@
 #include <xtrx_source_c.h>
 #endif
 
+#ifdef ENABLE_HYDRASDR
+#include <hydrasdr_source_c.h>
+#endif
+
 #include "arg_helpers.h"
 #include "source_impl.h"
 
@@ -173,6 +177,10 @@ source_impl::source_impl( const std::string &args )
 #ifdef ENABLE_XTRX
   dev_types.push_back("xtrx");
 #endif
+#ifdef ENABLE_HYDRASDR
+  dev_types.push_back("hydrasdr");
+#endif
+
   std::cerr << "gr-osmosdr "
             << GR_OSMOSDR_VERSION << " (" << GR_OSMOSDR_LIBVER << ") "
             << "gnuradio " << gr::version() << std::endl;
@@ -255,6 +263,10 @@ source_impl::source_impl( const std::string &args )
 #endif
 #ifdef ENABLE_XTRX
     for (std::string dev : xtrx_source_c::get_devices())
+      dev_list.push_back( dev );
+#endif
+#ifdef ENABLE_HYDRASDR
+    for (std::string dev : hydrasdr_source_c::get_devices())
       dev_list.push_back( dev );
 #endif
 
@@ -392,6 +404,13 @@ source_impl::source_impl( const std::string &args )
 #ifdef ENABLE_XTRX
     if ( dict.count("xtrx") ) {
       xtrx_source_c_sptr src = make_xtrx_source_c( arg );
+      block = src; iface = src.get();
+    }
+#endif
+
+#ifdef ENABLE_HYDRASDR
+    if ( dict.count("hydrasdr") ) {
+      hydrasdr_source_c_sptr src = make_hydrasdr_source_c( arg );
       block = src; iface = src.get();
     }
 #endif

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -181,7 +181,7 @@ source_impl::source_impl( const std::string &args )
   dev_types.push_back("hydrasdr");
 #endif
 
-  std::cerr << "gr-osmosdr "
+  std::cerr << "gr-osmosdr (boatbod) "
             << GR_OSMOSDR_VERSION << " (" << GR_OSMOSDR_LIBVER << ") "
             << "gnuradio " << gr::version() << std::endl;
   std::cerr << "built-in source types: ";

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(bindings)
 GR_PYTHON_INSTALL(
     FILES
     __init__.py
-    DESTINATION ${GR_PYTHON_DIR}/osmosdr
+    DESTINATION ${OSMOSDR_PYTHON_DIR}/osmosdr
 )
 
 ########################################################################

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -30,4 +30,4 @@ GR_PYBIND_MAKE_OOT(osmosdr
    gr::osmosdr
    "${osmosdr_python_files}")
 
-install(TARGETS osmosdr_python DESTINATION ${GR_PYTHON_DIR}/osmosdr COMPONENT pythonapi)
+install(TARGETS osmosdr_python DESTINATION ${OSMOSDR_PYTHON_DIR}/osmosdr COMPONENT pythonapi)


### PR DESCRIPTION
Add additional device initialization code to permit gr-osmosdr client apps to connect to hydrasdr devices when creating a osmocom.source() object.  Without this initialization - which is present for all other supported hardware types - the object constructor either fails to find the device or attempts to use an incorrect alternate device type.